### PR TITLE
Fix incorrect installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## 快速开始
 快速启动一个静态服务器
 ```bash
-npm install f2e-server-3 --save-dev
+npm install f2e-server3 --save-dev
 ```
 创建启动文件 start.mjs
 ```js


### PR DESCRIPTION
npm install f2e-server-3 --save-dev will result in a 404 error. The correct package name on npm should be "f2e-server3".
![image](https://github.com/user-attachments/assets/fe1a4908-4f08-4346-81f3-9d7319689fa6)
